### PR TITLE
Made the search API accessible

### DIFF
--- a/app/controllers/institutions_controller.rb
+++ b/app/controllers/institutions_controller.rb
@@ -92,26 +92,9 @@ class InstitutionsController < ApplicationController
     @countries = @countries.uniq
     @states = @states.uniq
 
-    if (@schools.length == 1)
-      href = "#{profile_path}?facility_code=#{@schools[0][:facility_code]}";
-      href += "&military_status=" + @inputs[:military_status]
-      href += "&spouse_active_duty=" + @inputs[:spouse_active_duty]
-      href += "&gi_bill_chapter=" + @inputs[:gi_bill_chapter]
-      href += "&cumulative_service=" + @inputs[:cumulative_service]
-      href += "&enlistment_service=" + @inputs[:enlistment_service]
-      href += "&consecutive_service=" + @inputs[:consecutive_service]
-      href += "&elig_for_post_gi_bill=" + @inputs[:elig_for_post_gi_bill]
-      href += "&number_of_dependents=" + @inputs[:number_of_dependents]
-      href += "&online_classes=" + @inputs[:online_classes]
-      href += "&institution_search" + @inputs[:institution_search]
-
-      redirect_to href
-      return
-    end
-    
     respond_to do |format|
       format.json { render json: @schools }
-      format.html
+      format.html { redirect_to @schools[0][:profile_url] if @schools.length == 1 }
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,8 +3,9 @@ Rails.application.routes.draw do
   
   get 'institutions/profile' => 'institutions#profile', as: :profile
   get 'institutions/autocomplete' => 'institutions#autocomplete', as: :autocomplete
+  get 'institutions/search' => 'institutions#search'
   post 'institutions/search' => 'institutions#search', as: :search
-  
+
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 


### PR DESCRIPTION
Example call:

http://127.0.0.1:3000/institutions/search.json?facility_code=28800938&military_status=veteran&spouse_active_duty=no&gi_bill_chapter=1606&cumulative_service=1.0&enlistment_service=3&consecutive_service=0.8&elig_for_post_gi_bill=no&number_of_dependents=0&online_classes=no&institution_search=lehigh

Things missing (i.e. for a future PR):
- Default/optional arguments (errors if any arguments are left out), or at least a graceful error
- Pagination/segmentation of results (This is what I'll work on next)
- Cleaner API URL routing (i.e. /api/v1/institutions/[criteria, etc])
