### PR TITLE
Adds a scroll bar to the search suggestions

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -43,3 +43,10 @@
 	  stroke-width: 1.5px;
 	}
 }
+
+.ui-autocomplete {
+  max-height: 200px;
+  overflow-y: auto;
+  /* prevent horizontal scrollbar */
+  overflow-x: hidden;
+}

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -55,7 +55,7 @@ class Institution < ActiveRecord::Base
   #############################################################################
   def self.autocomplete(search_term)
     Institution.select('facility_code as value, institution as label')
-      .where("institution ~* ?", "^#{search_term}").limit(10)
+      .where("institution ~* ?", "^#{search_term}")
   end
 
   #############################################################################


### PR DESCRIPTION
Does two things:
- Adds a scroll bar to the search suggestions
- Removes the 10 results limit to the search suggestions ( @rickleegit  : We can remove this if this isn't the desired interaction)

![image](https://cloud.githubusercontent.com/assets/950486/10866346/c09a48b8-8000-11e5-996f-a88b5011232f.png)

This PR will not work until PR #56 is merged, due to issues with the jQuery UI installation.
