### PR TITLE
/gi-bill-comparison-tool is the production URL

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -2,6 +2,6 @@
 
 require ::File.expand_path('../config/environment', __FILE__)
 
-map ENV['RAILS_RELATIVE_URL_ROOT'] || '/' do
+map Rails.application.config.relative_url_root || '/' do
   run Rails.application
 end

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,7 @@
 # This file is used by Rack-based servers to start the application.
 
 require ::File.expand_path('../config/environment', __FILE__)
-run Rails.application
+
+map ENV['RAILS_RELATIVE_URL_ROOT'] || '/' do
+  run Rails.application
+end

--- a/config/database.yml
+++ b/config/database.yml
@@ -11,3 +11,7 @@ test:
   adapter: postgresql
   database: travis_ci_test
   username: postgres
+
+production:
+  <<: *default
+  database: gi_bill_comparison_tool_production

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,6 +1,10 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # Application should be deployed at (base URL)/gi-bill-comparison-tool
+  ENV['RAILS_RELATIVE_URL_ROOT'] = "/gi-bill-comparison-tool"
+  config.assets.prefix = ENV['RAILS_RELATIVE_URL_ROOT'] || 'assets'
+
   # Code is not reloaded between requests.
   config.cache_classes = true
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -2,8 +2,7 @@ Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Application should be deployed at (base URL)/gi-bill-comparison-tool
-  ENV['RAILS_RELATIVE_URL_ROOT'] = "/gi-bill-comparison-tool"
-  config.assets.prefix = ENV['RAILS_RELATIVE_URL_ROOT'] || 'assets'
+  Rails.application.config.relative_url_root = "/gi-bill-comparison-tool"
 
   # Code is not reloaded between requests.
   config.cache_classes = true


### PR DESCRIPTION
To test, export the following environment variables:

```
export RAILS_SERVE_STATIC_FILES=true
export RAILS_ENV=production
```

Then hit `localhost:3000/gi-bill-comparison-tool`

Don't merge this yet, still trying to make this backwards compatible with the existing deployment.

This is needed to support a consistent deployment model when we go to GovCloud.