### PR TITLE
Move brakeman and other items into dev/test (breaks production deploy)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,13 +27,6 @@ gem 'coffee-rails', '~> 4.1.0'
 gem 'jquery-rails'
 gem 'jquery-ui-rails'
 
-# Security scanners
-gem 'brakeman'
-
-# for travis
-gem 'rainbow', '~> 2.1'
-gem 'bundler-audit'
-
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.0'
 
@@ -42,12 +35,6 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
-
-group :development, :test do
-  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug'
-  gem 'simplecov'
-end
 
 group :development do
   # Access an IRB console on exception pages or by using <%= console %> in views
@@ -65,12 +52,23 @@ group :development do
 end
 
 group :development, :test do
+  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
+  gem 'byebug'
+  gem 'simplecov'
+
 	gem 'rspec-rails'
   gem 'capybara'
   gem 'factory_girl_rails'
   gem 'database_cleaner'
   gem 'dotenv-rails'
   gem 'faker'
+
+  # Security scanners
+  gem 'brakeman'
+
+  # for travis
+  gem 'rainbow', '~> 2.1'
+  gem 'bundler-audit'
 end
 
 gem 'puma', '3.2.0'


### PR DESCRIPTION
Found a bug during deploy, where puma was failing on trying to load brakeman in production mode.

Blocking https://github.com/department-of-veterans-affairs/vets.gov-ops/pull/108