### PR TITLE
Remove VetSuccess on Campus popup link

### DIFF
--- a/app/views/profile_components/_veteran_summary.html.erb
+++ b/app/views/profile_components/_veteran_summary.html.erb
@@ -66,9 +66,7 @@
 		        %>
 		        <li>
 		        	<%= v_str.html_safe %> 
-		        	<a id="go" rel="leanModal" name="status" href="#">
-		        		<span class="programs-text">VetSuccess on Campus</span>
-		        	</a>
+		        	<span class="programs-text">VetSuccess on Campus</span>
 		        	<%= h(l_str.html_safe) %>
 		        </li>
 


### PR DESCRIPTION
This felt like the right behavior for the information I have. If there is no VetSuccess coordinator on campus, there is now no link to anything. If there is a VetSuccess coordinator, that person's name still shows up after the text for "VetSuccess on Campus" and clicking the name is mailto link, so it takes you to your mail client. Example of that is here:

![screen shot 2016-07-25 at 9 28 20 pm](https://cloud.githubusercontent.com/assets/4719765/17123044/c2cf9e4a-52ae-11e6-9ca0-a75dff3839b1.png)

Thoughts on if that's what you think should happen @rickleegit ?  Seems strange to me that there is a modal for every other one of these items but not VetSuccess on Campus, but there just doesn't seem to be one so this feels like the best we can do right now?