### PR TITLE
Avoid hard-coding url path

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -2,7 +2,7 @@ Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Application should be deployed at (base URL)/gi-bill-comparison-tool
-  Rails.application.config.relative_url_root = "/gi-bill-comparison-tool"
+  # but relative_url_root is derived from environment variables
 
   # Code is not reloaded between requests.
   config.cache_classes = true


### PR DESCRIPTION
See #402 

In my manual testing in deployments to dev, the default_env entry in deploy.rb did not have any effect so I'm not bothering to change it here.