### PR TITLE
Avoid NoMethodError on json response due to nil page parameter

### DIFF
--- a/app/controllers/institutions_controller.rb
+++ b/app/controllers/institutions_controller.rb
@@ -106,7 +106,7 @@ class InstitutionsController < ApplicationController
     end
 
     respond_to do |format|
-      format.json { render json: @kilter.page(@inputs[:page].try(:to_i)) }
+      format.json { render json: @kilter.page(@page) }
       format.html { redirect_to profile if profile.present? }
     end
   end


### PR DESCRIPTION
Resolves #415. 

Code was trying to read page value from inputs even though method params_to_inputs explicitly doesn't set page in inputs on line 141. 

Reproduced in dev with a curl request, patched locally and retried with no error on subsequent curl request. 