### PR TITLE
Avoid 1 full table scan during search

### DIFF
--- a/app/controllers/institutions_controller.rb
+++ b/app/controllers/institutions_controller.rb
@@ -97,7 +97,7 @@ class InstitutionsController < ApplicationController
     @kilter.set_size.page(@page)
 
     # Go directly to school if only one result
-    if @rset.length == 1 && @inputs[:source] == "home"
+    if @kilter.count_filtered == 1 && @inputs[:source] == "home"
       @inputs[:facility_code] = @kilter.filtered_rset.first.facility_code
       profile = @kilter.to_href(profile_path, @inputs)
     else

--- a/lib/kilter.rb
+++ b/lib/kilter.rb
@@ -18,7 +18,7 @@ class Kilter
 		raise ArgumentError if rset.nil? || !rset.kind_of?(ActiveRecord::Relation)
 
 		@filtered_rset = rset
-		@count_all = @filtered_rset.length
+		@count_all = @filtered_rset.size
 
 		info
 		set_size(DEFAULT_ITEMS_PER_PAGE)
@@ -96,7 +96,7 @@ class Kilter
 	## count_filtered
 	#############################################################################
 	def count_filtered
-		filtered_rset.length
+		filtered_rset.size
 	end
 
 	#############################################################################


### PR DESCRIPTION
Resolves #410 by avoiding the use of ActiveRecord::Result.length. Improves the situation well enough given cost/benefit. 