### PR TITLE
Pv filter group count

### DIFF
--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -8,6 +8,7 @@ class Institution < ActiveRecord::Base
     31 => 'Town', 32 => 'Town', 33 => 'Town',
     41 => 'Rural', 42 => 'Rural', 43 => 'Rural'
   }
+  AUTOCOMPLETE_MAX = 40
 
   belongs_to :institution_type, inverse_of: :institutions
 
@@ -112,7 +113,7 @@ class Institution < ActiveRecord::Base
     search_term = search_term.try(:strip).try(:downcase)
 
     Institution.select("facility_code as value, institution as label")
-      .where("lower(institution) LIKE (?)", "#{search_term}%")
+      .where("lower(institution) LIKE (?)", "#{search_term}%").limit(AUTOCOMPLETE_MAX)
   end
 
   #############################################################################

--- a/lib/kilter.rb
+++ b/lib/kilter.rb
@@ -162,16 +162,6 @@ class Kilter
 			end
 		end
 		self
-
-#		@filtered_rset.find_each do |r|
-#			@tracked.keys.each do |k|
-#				# use send to handle columns that may be overriden in models
-#				value = r.send(k.to_s)
-#				@tracked[k][value.to_s] += 1 unless (value.nil? || value.try(:empty?))
-#			end
-#		end
-#
-#		self
 	end
 
 	#############################################################################

--- a/lib/kilter.rb
+++ b/lib/kilter.rb
@@ -155,9 +155,9 @@ class Kilter
 		return @tracked[col] unless count_operation
 
 		@tracked.keys.each do |k|
-			groups = @filtered_rset.model.from(@filtered_rset).group(k.to_s).count
+			groups = model.from(@filtered_rset).group(k.to_s).count
 			groups.each do |val,num|
-				@tracked[k][val.to_s] = num unless (val.nil? || val.try(:empty?))
+				@tracked[k][val.to_s] = num unless val.blank?
 			end
 		end
 		self

--- a/lib/kilter.rb
+++ b/lib/kilter.rb
@@ -149,7 +149,7 @@ class Kilter
 	## performed on all tracked fields.
 	#############################################################################
 	def count(col = nil)
-		count_operation = col.nil? || col.empty?
+		count_operation = col.blank?
 
 		return self unless (@tracked.keys.include?(col) || count_operation)
 		return @tracked[col] unless count_operation
@@ -157,8 +157,7 @@ class Kilter
 		@tracked.keys.each do |k|
 			groups = @filtered_rset.model.from(@filtered_rset).group(k.to_s).count
 			groups.each do |val,num|
-				@tracked[k][val.to_s] = num
-				puts "#{k}: #{val} -> #{num}"
+				@tracked[k][val.to_s] = num unless (val.nil? || val.try(:empty?))
 			end
 		end
 		self

--- a/lib/kilter.rb
+++ b/lib/kilter.rb
@@ -154,15 +154,24 @@ class Kilter
 		return self unless (@tracked.keys.include?(col) || count_operation)
 		return @tracked[col] unless count_operation
 
-		@filtered_rset.each do |r|
-			@tracked.keys.each do |k|
-				# use send to handle columns that may be overriden in models
-				value = r.send(k.to_s)
-				@tracked[k][value.to_s] += 1 unless (value.nil? || value.try(:empty?))
+		@tracked.keys.each do |k|
+			groups = @filtered_rset.model.from(@filtered_rset).group(k.to_s).count
+			groups.each do |val,num|
+				@tracked[k][val.to_s] = num
+				puts "#{k}: #{val} -> #{num}"
 			end
 		end
-
 		self
+
+#		@filtered_rset.find_each do |r|
+#			@tracked.keys.each do |k|
+#				# use send to handle columns that may be overriden in models
+#				value = r.send(k.to_s)
+#				@tracked[k][value.to_s] += 1 unless (value.nil? || value.try(:empty?))
+#			end
+#		end
+#
+#		self
 	end
 
 	#############################################################################

--- a/spec/models/institution_spec.rb
+++ b/spec/models/institution_spec.rb
@@ -134,10 +134,10 @@ RSpec.describe Institution, type: :model do
       end
     end
 
-    it "nil or empty returns all institutions" do
+    it "nil or empty returns up to max returned institutions" do
       [nil, "", "      "].each do |arg|
         inst = Institution.autocomplete(arg)
-        expect(inst.size).to eql(Institution.all.count)
+        expect(inst.size).to eql([Institution::AUTOCOMPLETE_MAX, Institution.all.count].min)
       end
     end
   end


### PR DESCRIPTION
Fixes #435. 

Instead of iterating through the entire result set to generate counts for each filter category, execute a series of count...group by queries on each filter category. 

Comparative before/after memory usage can be seen in the below screenshot...the big memory fluctuations on the left side are the result of executing single-letter searches without this change - cause a memory use spike of 100 megs or more. The tiny blip in the red/blue lines on the very right side of the graph is the result of multiple similar single-letter queries with this PR in place. 

<img width="653" alt="screen shot 2016-11-08 at 10 45 36 pm" src="https://cloud.githubusercontent.com/assets/20694532/20129590/b10d90e0-a605-11e6-8937-73c7184e7c3a.png">
