### PR TITLE
[WIP] Jenkinsfile to replace travis for CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,8 @@ group :development, :test do
   gem 'byebug'
   gem 'simplecov'
 
-	gem 'rspec-rails'
+  gem 'rspec-rails'
+  gem 'therubyracer'
   gem 'capybara'
   gem 'factory_girl_rails'
   gem 'database_cleaner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,7 @@ GEM
     jquery-ui-rails (5.0.5)
       railties (>= 3.2.16)
     json (1.8.3)
+    libv8 (3.16.14.15)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.4)
@@ -182,6 +183,7 @@ GEM
     rake (11.2.2)
     rdoc (4.2.2)
       json (~> 1.4)
+    ref (2.0.0)
     respond-rails (1.0.1)
       railties (>= 3.1.0)
     rspec-core (3.5.2)
@@ -231,6 +233,9 @@ GEM
     stellar-js-rails (0.6.2.1)
       jquery-rails (>= 2.0)
       railties (>= 3.2.0, < 5.0)
+    therubyracer (0.12.2)
+      libv8 (~> 3.16.14.0)
+      ref
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.5)
@@ -299,9 +304,10 @@ DEPENDENCIES
   sdoc (~> 0.4.0)
   simplecov
   spring
+  therubyracer
   uglifier (>= 1.3.0)
   va_common (~> 0.4.4)
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.13.1
+   1.13.6

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 pipeline {
-  agent label:'vec-testing'
+  agent label:'rails-testing'
   stages {
     stage('Checkout Code') {
       steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,28 @@
+pipeline {
+  agent label:'vec-testing'
+  stages {
+    stage('Checkout Code') {
+      steps {
+        checkout scm
+      }
+    }
+
+    stage('Install bundle') {
+      steps {
+        sh 'bash --login -c "bundle install --path vendor/bundle --without development"'
+      }
+    }
+
+    stage('Ensure database') {
+      steps {
+        sh 'bash --login -c "bundle exec rake db:create db:migrate load_csv[data.csv]"'
+      }
+    }
+
+    stage('Run tests') {
+      steps {
+        sh 'bash --login -c "bundle exec rake ci"'
+      }
+    }
+  }
+}


### PR DESCRIPTION
Jenkinsfile replaces travis for pre-merge CI. 
Hold pending consensus by devops on whether all rails apps can share a jenkins swarm node (so replace vec-testing label with rails-testing.

Adding therubyracer as a javascript engine for dev/testing environments (required by the uglifier gem), as opposed to installing node.js on the jenkins instance. 
